### PR TITLE
Jeffrey thompson

### DIFF
--- a/include/Collision.h
+++ b/include/Collision.h
@@ -13,6 +13,7 @@ class CBase  //base for CollisionEngine AND Connections - the basics needed for 
 public:
 	class Collision;
 	CBase() {}
+	~CBase() {}
 	virtual void ResolveCollision(Collision* ResolveMe) {}  //this is how collisions get resolved
 	virtual Collision* Detect(Iterator<PointMass>& PointMasses) {return NULL;} //returns a collision object if one needed - the soonest to occur collision
 		//in the case of Connections, if the Connection is "connected" at t=0 then do not generate a collision, go ahead and modify the PointMasses involved.
@@ -26,10 +27,9 @@ public:
 	bool operator < (const Collision& Rhs)const; //used in sorting
 	bool operator > (const Collision& Rhs)const;
 	
-	template <class T> Iterator<PointMass> PMinvolved; //add and access PointMasses involved here, look at Iterator class for how to use
 	double timeToCollision;  //as it says
-private:
 	std::vector<PointMass*> pmInvolved; //the dynamic array that holds the PointMass pointers
+private:
 	CRF whoResolvesMe; //function pointer
 };
 

--- a/include/Collision.h
+++ b/include/Collision.h
@@ -1,0 +1,36 @@
+#ifndef COLLISION_H
+#define COLLISION_H
+
+#include <vector>
+#include "pointmass.h"
+#include "iterator.h"
+
+class Collision;
+typedef void (*CRF)(Collision*);  //Collision Resolution Function - passed the collision object it created
+
+class CBase  //base for CollisionEngine AND Connections - the basics needed for collision resolution
+{
+public:
+	class Collision;
+	CBase() {}
+	virtual void ResolveCollision(Collision* ResolveMe) {}  //this is how collisions get resolved
+	virtual Collision* Detect(Iterator<PointMass>& PointMasses) {return NULL;} //returns a collision object if one needed - the soonest to occur collision
+		//in the case of Connections, if the Connection is "connected" at t=0 then do not generate a collision, go ahead and modify the PointMasses involved.
+};
+
+class CBase::Collision  //base class for Collisions, each CollisionEngine or Connection can put whatever data in their child they need.
+{
+public:
+	Collision(double TimeToCollision, CRF WhoResolvesMe=NULL); //in case of a Connection just set the TimeToCollision, CollisionEngines need to send CRF and set PMinvolved
+	void Resolve(); //send us back to our maker to resolve the collision - objects will be advanced to collision time beforehand.
+	bool operator < (const Collision& Rhs)const; //used in sorting
+	bool operator > (const Collision& Rhs)const;
+	
+	template <class T> Iterator<PointMass> PMinvolved; //add and access PointMasses involved here, look at Iterator class for how to use
+	double timeToCollision;  //as it says
+private:
+	std::vector<PointMass*> pmInvolved; //the dynamic array that holds the PointMass pointers
+	CRF whoResolvesMe; //function pointer
+};
+
+#endif // COLLISION_H

--- a/include/CollisionEngine.h
+++ b/include/CollisionEngine.h
@@ -3,15 +3,11 @@
 
 #include "Collision.h"
 
-
-
 class CollisionEngine : public CBase
 {
 public:
 	CollisionEngine() {}
 	//currently does nothing
-private:
-
 };
 
 #endif // COLLISIONENGINE_H

--- a/include/CollisionEngine.h
+++ b/include/CollisionEngine.h
@@ -1,29 +1,17 @@
 #ifndef COLLISIONENGINE_H
 #define COLLISIONENGINE_H
-#include "PointMass.h"
+
+#include "Collision.h"
 
 
 
-
-typedef double (*PairCollision)(PointMass*,PointMass*);
-typedef double (*Collision)(void);
-
-class CollisionEngine
+class CollisionEngine : public CBase
 {
 public:
-    CollisionEngine();
-
-    float t;
-    PointMass* A;
-    PointMass* B;
+	CollisionEngine() {}
+	//currently does nothing
 private:
-    struct Collision {
-        double time;
-        PointMass* a;
-        PointMass* b;
-        bool operator<(const Collision& RHS);
-        bool operator>(const Collision& RHS);
-    };
+
 };
 
 #endif // COLLISIONENGINE_H

--- a/include/Connection.h
+++ b/include/Connection.h
@@ -1,10 +1,12 @@
 #ifndef CONNECTION_H
 #define CONNECTION_H
 
-class Connection
+#include "Collision.h"
+
+class Connection : public CBase
 {
-
-
+	Connection() {}
+	//currently does nothing
 };
 
 #endif // CONNECTION_H

--- a/include/iterator.h
+++ b/include/iterator.h
@@ -3,27 +3,23 @@
 
 #include <vector>
 
-#include "Vectors.h"
-#include "PointMass.h"
-#include "CollisionEngine.h"
-#include "Connection.h"
-
-class PhysicsEngine;
-
 template <class T>  
-class PhysicsEngine::Iterator       //built for vectors filled with pointers 
+class Iterator       //built for dynamic arrays filled with pointers (our template is for the object however, not the object pointers)
 {
-	Iterator(); //must be set by a operator = to be useful
+	Iterator(); //must be set by a operator = afterwards to be useful
 	Iterator(Iterator<T>& CopyThis);
-	Iterator(std::vector<T>& Myvector);  //only physicsEngine can use this one (as only physics engine has access to the vectors)
+	Iterator(std::vector<T>& Myvector);  //should only be used in the original Iterator which has access to the private std::vector
 
-//these add or remove items to our vector
-	void Append(const T* AddThis); //append AddThis to the end of the vector  
-	void Delete(T* const DeleteThis);   //remove the object from our vector, inform connections of it's removal and delete the memory allocation to it.
-	void Delete(const Iterator<T>& DeleteThis);
+//these add or remove items to our dynamic array
+	void Append(const T* AddThis); //append AddThis to the end of the dynamic array  
+	void Delete(T* const DeleteThis);   //remove the object from our dynamic array, and delete the memory allocation to it.
+	void Delete(const Iterator<T>& DeleteThis);  //by other methods
 	void Delete(unsigned int Element);
+	void Clear();   //remove all elements from our dynamic array
+//deleting a pointmass can affect connections...  when we have connections we'll need to make a child class for PointMasses
 
 //these access the object we hold - as the vector holds pointers a further dereference(*) is needed to access the actual object (the pointers returned are const, but the object they point to are not)
+//both these will do a try/catch with a NULL being returned if a throw was caught.  *** No internal error checking ***
 	T* operator * ()const;  //dereference to currently selected element - returns a pointer or NULL if out of range
 	T* operator [] (unsigned int Element)const; //returns the Element'th element without changing our internal pointing, if out of range we return NULL
 
@@ -35,7 +31,7 @@ class PhysicsEngine::Iterator       //built for vectors filled with pointers
 	Iterator<T> operator -- (int);
 	Iterator<T>& operator += (int Rhs); //change our pointing by the int sent
 	Iterator<T>& operator -= (int Rhs);
-	//if our internal pointing is moved out of range, dereference will only return NULL until reset by one of these three or a operator =
+	//if our internal pointing is moved out of range, it can be reset by one of these three or a operator = 
 	Iterator<T>& SetTo(unsigned int Element); //sets our internal pointer to the number of passed element
 	Iterator<T>& SetToFirst(); //sets our internal pointer to the first element [0]
 	Iterator<T>& SetToLast(); //sets our internal pointer to the last element [*myvector.size]
@@ -45,10 +41,11 @@ class PhysicsEngine::Iterator       //built for vectors filled with pointers
 	Iterator<T> operator - (int Rhs)const;
 	Iterator<T> First()const;  //returns a Iterator<t> set to first element 
 	Iterator<T> Last()const;  //returns a Iterator<t> set to last element 
-
+	unsigned int Element()const;  //returns the element number we are pointing to
+	int Find(const T* FindThis);   //returns the element number for the object sent - returns -1 if not found
 private:
 	std::vector<T*>* myvector;  //the vector we track and access
-	unsigned int i; //if moved out of valid range it must be reset by a SetTo or operator =. Until then the iterator will only return NULL
+	unsigned int i; //our internal pointing value
 };
 
 

--- a/include/physicsengine.h
+++ b/include/physicsengine.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "Vectors.h"
-#include "PointMass.h"
 #include "CollisionEngine.h"
 #include "Connection.h"
 
@@ -15,23 +14,22 @@ class PhysicsEngine
 {
 public:
 	PhysicsEngine();  //must be loaded with objects and functions after initialization
-	template <class T> class Iterator;
 
 	void Advance(double TimeSlice);  //advance a sent time slice recalculating forces, trajectory and resolving any collisions
 	void SetBaseForce(BaseForce BaseForceFunction); //set the function that sets the base force in our system
 	void SetCollisionEngine(CollisionEngine* CollisionEngineObj); //set the collision engine (class) we use
 
-	Iterator<PointMass> PointMasses;  //look at Iterator class declaration for how to use these
-	Iterator<Connection> Connections;
-	Iterator<PairForce> PairForces;
-	Iterator<Collision> Collisions;
+	template <class T> Iterator<PointMass> PointMasses;  //look at Iterator class declarations for how to use these Iterators
+	template <class T> Iterator<Connection> Connections;
+	template <class T> Iterator<PairForce> PairForces;
 
  private:
-	std::vector<PointMass*> pointMasses;  //our dynamic arrays of object pointers
+	std::vector<PointMass*> pointMasses;  //our dynamic arrays of pointers
 	std::vector<Connection*> connections;
-	std::vector<PairForce> pairForces; 
-	std::vector<Collision*> collisions;
+	std::vector<PairForce> pairForces;
 
+
+	Collision* firstCollision;  //the first collision that happens
 	CollisionEngine* collisionEngine;  //the engine we use
 	BaseForce baseForceFunction;  //the base force function we use
 	double timeSlice;  //the timeslice we work through

--- a/include/physicsengine.h
+++ b/include/physicsengine.h
@@ -28,7 +28,6 @@ public:
 	std::vector<Connection*> connections;
 	std::vector<PairForce> pairForces;
 
-
 	Collision* firstCollision;  //the first collision that happens
 	CollisionEngine* collisionEngine;  //the engine we use
 	BaseForce baseForceFunction;  //the base force function we use


### PR DESCRIPTION
_Updated_ Iterator removed from Collision and added a virtual destructor to CBase class

--== Iterator ==--
-Moved Iterator to be stand-alone so it can be used in the std::vector that is in Collision (and possibly elsewhere)
-added Find(T*) and Clear()

--== PhysicsEngine ==--
-deleted the std::vector and made it a single pointer. I decided to run with the first collision only method and if we want to change it later we can, it makes CollisionEngine and Connections more consistent in how they work and cleaner. It won't be hard to change later if we decide to.

--==Collisions==--
-New File!
-here we have CBase with is the base class for CollisionEngine and Connections which has all the (virtual) functions physics engine will use.
-Detect() accepts a Iterator instead of CollisonEngine holding it internally.
-Collision is a class nested within CBase which uses std::vector to hold PointMasses Involved with the collision.

--==Collision Engine==--
-Empty child of CBase at the moment, which is enough to let everything else work. We can work on this again after getting PhysicsEngine and Iterator running.

--==Connection==--
-Same status as CollisionEngine
